### PR TITLE
Only parse <title> tag in <head>

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ MetaInspector.prototype.getTitle = function()
 
 	if(this.title === undefined)
 	{
-		this.title = this.parsedDocument('title').text();
+		this.title = this.parsedDocument('head > title').text();
 	}
 
 	return this;


### PR DESCRIPTION
Some sites use SVG elements, which contain a `<title>` tag. Should look for page title in the `<head>`

For example, https://www.kickstarter.com has 64 `<title>` tags
